### PR TITLE
debugged the modal to add a creator: wasn't working on some pages

### DIFF
--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -7,7 +7,6 @@ class CreatorsController < ApplicationController
     @batches = Batch.where(status: ["active", "closed"]).order(created_at: :asc)
     @languages = Creator.find_all_languages
     @creators = policy_scope(Creator)
-    @creator = Creator.new
     if params[:name].present?
       sql_query = "description ILIKE :query OR youtube_name ILIKE :query"
       @creators = @creators.where(sql_query, query: "%#{params[:name]}%")

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,8 +3,6 @@ class PagesController < ApplicationController
 
 
   def home
-    # for creation modal (tbc)
-    @creator = Creator.new
     # for upvote creation
     @upvote = Upvote.new
     # for showcasing div

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,6 @@ class UsersController < ApplicationController
     authorize @user
     @user.update_level
     @categories = ActsAsTaggableOn::Tag.order(:name)
-    @creator = Creator.new
   end
 
   def update

--- a/app/views/creators/new_error.html.erb
+++ b/app/views/creators/new_error.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h2 class="text-center">Enter the URL of the creator's channel you want to share</h2>
+  <h2 class="text-center">Something went wrong... Please review the problems and try again</h2>
   <div class="row">
     <div class="col-xs-12 col-sm-offset-4 col-sm-4">
       <div class="text-center" style="margin-top:50px">

--- a/app/views/shared/_modal_creator.html.erb
+++ b/app/views/shared/_modal_creator.html.erb
@@ -14,7 +14,8 @@
         </div>
         <div class="modal-body">
           <% if current_user.allowed_to_upload? %>
-            <%= simple_form_for @creator, url: creators_path do |form| %>
+            <% @new_creator = Creator.new %>
+            <%= simple_form_for @new_creator, url: creators_path do |form| %>
               <div class="stuff-wrapper" style="margin: 40px 20px;">
                 <%= form.input :channel_url, required: true, as: :string, id: "form-input-no-border", label: false, placeholder: "https://www.youtube.com/channel/mychanel", input_html: {class:"stuff"}
                  %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,7 +13,9 @@
     <% if user_signed_in? %>
 
       <!-- Links when logged in -->
+
       <%= link_to "Add a new creator", "#creator-modal", "data-toggle" => "modal", class: "navbar-creators-item navbar-creators-link" %>
+      <%= render 'shared/modal_creator' %>
       <%= link_to "See all Creators", search_path, class: "navbar-creators-item navbar-creators-link" %>
       <%#= link_to "My page", user_path(current_user), class: "navbar-creators-item navbar-creators-link" %>
 


### PR DESCRIPTION
Il manquait un putain de render de la modal dans le code de la navbar. Et ça marchait sur les pages : 
- #home pcq il y avait le render dans le bouton "add a creator"
- creators#index pcq il y avait le render dans le bout de code si la recherche renvoie aucun résultat, avec le "didn't find the creator you wanted ?"

Pour que la modal se lance bien (comme elle intègre un form) il faut un @creator = Creator.new. Plutôt que mettre cette ligne dans tous les contrôleurs pour que ça soit bien accessible sur chaque page, je l'ai mis directement dans la modal. Comme c'est dans la navbar, donc sur toutes les pages, c'est bien plus simple et ça évitera les oublis à l'avenir si on rajoute des pages !